### PR TITLE
Fixed-applicants-index-page

### DIFF
--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -19,7 +19,7 @@
   <% @applicants.each do |applicant| %>
     <tr>
       <td><%= applicant.name %></td>
-      <td><%= applicant.project_title %></td>
+      <td><%= applicant.project.title %></td>
       <td><%= applicant.status.titleize %></td>
       <td><%= link_to "Show this applicant", applicant %></td>
     </tr>


### PR DESCRIPTION
Fixed the bug of applicants index page on which we can clearly see the different project titles.


![ChangeX-App](https://user-images.githubusercontent.com/11027786/206688776-f0b2a9f1-ee2c-407c-aef9-56eef0bddd77.png)
